### PR TITLE
feat: translate-transaction-type

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,6 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
-      dotenv:
-        specifier: ^16.4.5
-        version: 16.4.5
       lucide-react:
         specifier: ^0.383.0
         version: 0.383.0(react@18.3.1)
@@ -1137,10 +1134,6 @@ packages:
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
-
-  dotenv@16.4.5:
-    resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
-    engines: {node: '>=12'}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -2941,8 +2934,6 @@ snapshots:
   doctrine@3.0.0:
     dependencies:
       esutils: 2.0.3
-
-  dotenv@16.4.5: {}
 
   eastasianwidth@0.2.0: {}
 

--- a/src/components/component/dashboard.tsx
+++ b/src/components/component/dashboard.tsx
@@ -408,8 +408,8 @@ function Transactions() {
                       <SelectContent>
                         <SelectGroup>
                           <SelectLabel>Tipos de transações</SelectLabel>
-                          <SelectItem value="INCOME">INCOME</SelectItem>
-                          <SelectItem value="EXPENSE">EXPENSE</SelectItem>
+                          <SelectItem value="INCOME">RENDA</SelectItem>
+                          <SelectItem value="EXPENSE">DESPESA</SelectItem>
                         </SelectGroup>
                       </SelectContent>
                     </Select>
@@ -462,7 +462,7 @@ function Transactions() {
                     <div className="pt-3 text-start">
                       <p>
                         <span className="font-bold">Tipo de transação: </span>
-                        {data.type}
+                        {data.type == 'INCOME'? 'RENDA' : 'DESPESA'}
                       </p>
                     </div>
                   </CardHeader>


### PR DESCRIPTION
## Proposta deste PR
- Assim como especificado
  na Issue #35, é preciso mostrar ao usuário um selecionador de itens com o tipo de transação traduzida.

## Impactos deste PR
- Tradução dos tipos de transação.

## Evidências de teste
![image](https://github.com/JonasFortes12/MEICash-front-end/assets/65193369/3231549d-6a55-4ac2-ad86-a8a76bc4ae6a)
